### PR TITLE
[FEATURE] Add TYPO3 V10 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "sentry/sentry": "^2.1",
     "php-http/guzzle6-adapter": "^2.0",
-    "typo3/cms-core": "^9.5"
+    "typo3/cms-core": "^9.5 || ^10.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Log/Writer/SentryBreadcrumbWriter.php
+++ b/src/Log/Writer/SentryBreadcrumbWriter.php
@@ -25,7 +25,7 @@ class SentryBreadcrumbWriter extends AbstractWriter
         \Sentry\addBreadcrumb(
             Breadcrumb::fromArray(
                 [
-                    'level' => $this->getSeverityFromLevel($record->getLevel()),
+                    'level' => $this->getSeverityFromLevel(LogLevel::normalizeLevel($record->getLevel())),
                     'message' => $record->getMessage(),
                     'data' => $record->getData(),
                     'category' => $record->getComponent(),

--- a/src/Log/Writer/SentryWriter.php
+++ b/src/Log/Writer/SentryWriter.php
@@ -37,7 +37,7 @@ class SentryWriter extends AbstractWriter
         $hub = Hub::getCurrent();
         $hub->withScope(function (Scope $scope) use ($hub, $record) {
             $payload = [
-                'level' => $this->getSeverityFromLevel($record->getLevel()),
+                'level' => $this->getSeverityFromLevel(LogLevel::normalizeLevel($record->getLevel())),
                 'message' => $record->getMessage(),
             ];
             $recordData = $record->getData();
@@ -61,7 +61,7 @@ class SentryWriter extends AbstractWriter
                 unset($recordData['fingerprint']);
             }
             $scope->setExtra('typo3.component', $record->getComponent());
-            $scope->setExtra('typo3.level', LogLevel::getName($record->getLevel()));
+            $scope->setExtra('typo3.level', LogLevel::getName(LogLevel::normalizeLevel($record->getLevel())));
             $scope->setExtra('typo3.request_id', $record->getRequestId());
             if (!empty($recordData['tags'])) {
                 foreach ($recordData['tags'] as $key => $value) {

--- a/src/Sentry.php
+++ b/src/Sentry.php
@@ -50,6 +50,7 @@ final class Sentry
         unset($options['typo3_integrations']);
         $httpOptions = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
         $httpOptions['verify'] = filter_var($httpOptions['verify'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $httpOptions['verify'];
+        if (empty($httpOptions['handler'])) unset($httpOptions['handler']);
         $typo3HttpClient = Client::createWithConfig($httpOptions);
         $clientBuilder = ClientBuilder::create($options);
         $clientBuilder->setHttpClient($typo3HttpClient);


### PR DESCRIPTION
This commit make the package compatible with TYPO3 V10.

Changes:

- composer.json
Allow TYPO3 version 10.4 and above

- SentryWriter.php, SentryBreadcrumbWriter.php
Adjust methods to be compatible with PSR-3. See also https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-88799-IntroducedPSR-3CompatibleLoggingAPI.html

- Sentry.php
Not sure about this one. It removes the 'handler' from the config array, if it is empty. Otherwise it leads to an exception in `vendor/guzzlehttp/guzzle/src/Client.php` line 65. IMHO this line should test on `empty($config['handler'])`
